### PR TITLE
Listen to kytos/of_core.flow_stats.received

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ All notable changes to the flow_stats NApp will be documented in this file.
 Added
 =====
 
+- Added from_replies_flows function in GenericFlow to map FLOW04
+
 Changed
 =======
 


### PR DESCRIPTION
Fixes #21 

This PR deals with the kytos/of_core.flow_stats.received event for OF 0x04, that assembles the replies https://github.com/kytos-ng/of_core#kytos/+of_core.flow_stats.received. The new method 'handle_stats_received' looks for 'replies_flows' in the event content, iterates through it, and sets the generic flows.
In addition, unit tests have been verified.