### PR TITLE
Feature upgrade core development dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -593,7 +593,6 @@ class Main(KytosNApp):
             replies_flows = event.content['replies_flows']
             self.handle_stats_reply_received(switch, replies_flows)
 
-    # pylint: disable=no-self-use
     def handle_stats_reply_received(self, switch, replies_flows):
         """Iterate on the replies and set the generic flows"""
         switch.generic_flows = [GenericFlow.from_replies_flows(flow)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -3,4 +3,5 @@
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
 -e git+https://github.com/kytos-ng/sdntrace.git#egg=amlight-sdntrace
 -e .[dev]
+pytest-asyncio==0.18.3
 black==22.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@
     # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/sdntrace.git#egg=amlight-sdntrace
     # via -r requirements/dev.in
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
     # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
     # via -r requirements/dev.in
@@ -16,14 +16,26 @@
     # via
     #   -r requirements/dev.in
     #   kytos
-astroid==2.9.3
+asgiref==3.5.2
+    # via
+    #   flask
+    #   kytos
+astroid==2.12.9
     # via pylint
+asttokens==2.0.8
+    # via
+    #   kytos
+    #   stack-data
 attrs==21.4.0
     # via pytest
 backcall==0.1.0
     # via
     #   ipython
     #   kytos
+bidict==0.22.0
+    # via
+    #   kytos
+    #   python-socketio
 black==22.3.0
     # via -r requirements/dev.in
 blinker==1.4
@@ -40,7 +52,7 @@ charset-normalizer==2.0.10
     # via
     #   amlight-sdntrace
     #   requests
-click==8.0.3
+click==8.1.3
     # via
     #   black
     #   flask
@@ -52,59 +64,64 @@ decorator==4.4.2
     # via
     #   ipython
     #   kytos
-    #   traitlets
 dill==0.3.4
-    # via amlight-sdntrace
+    # via
+    #   amlight-sdntrace
+    #   pylint
 distlib==0.3.4
     # via virtualenv
 docopt==0.6.2
     # via yala
-docutils==0.18.1
+docutils==0.19
     # via
     #   kytos
     #   python-daemon
 elastic-apm[flask]==6.9.1
     # via kytos
+executing==1.0.0
+    # via
+    #   kytos
+    #   stack-data
 filelock==3.4.1
     # via
     #   tox
     #   virtualenv
-flask==1.1.2
+flask[async]==2.1.3
     # via
     #   flask-cors
     #   flask-socketio
     #   kytos
-flask-cors==3.0.8
+flask-cors==3.0.10
     # via kytos
-flask-socketio==4.2.1
+flask-socketio==5.2.0
     # via kytos
 idna==3.3
     # via
     #   amlight-sdntrace
     #   requests
+importlib-metadata==4.12.0
+    # via
+    #   flask
+    #   kytos
 iniconfig==1.1.1
     # via pytest
-ipython==7.13.0
+ipython==8.1.1
     # via kytos
-ipython-genutils==0.2.0
-    # via
-    #   kytos
-    #   traitlets
 isort==5.10.1
     # via
     #   pylint
     #   yala
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via
     #   flask
     #   kytos
-janus==0.4.0
+janus==1.0.0
     # via kytos
 jedi==0.16.0
     # via
     #   ipython
     #   kytos
-jinja2==2.11.1
+jinja2==3.1.2
     # via
     #   flask
     #   kytos
@@ -114,9 +131,13 @@ lockfile==0.12.2
     # via
     #   kytos
     #   python-daemon
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via
     #   jinja2
+    #   kytos
+matplotlib-inline==0.1.6
+    # via
+    #   ipython
     #   kytos
 mccabe==0.6.1
     # via pylint
@@ -132,10 +153,6 @@ parso==0.6.2
     #   kytos
 pathspec==0.9.0
     # via black
-pathtools==0.1.2
-    # via
-    #   kytos
-    #   watchdog
 pep517==0.12.0
     # via pip-tools
 pexpect==4.8.0
@@ -165,6 +182,10 @@ ptyprocess==0.6.0
     # via
     #   kytos
     #   pexpect
+pure-eval==0.2.2
+    # via
+    #   kytos
+    #   stack-data
 py==1.11.0
     # via
     #   pytest
@@ -173,13 +194,13 @@ pycodestyle==2.8.0
     # via yala
 pydantic==1.9.0
     # via kytos
-pygments==2.11.2
+pygments==2.13.0
     # via
     #   ipython
     #   kytos
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via kytos
-pylint==2.12.2
+pylint==2.15.0
     # via yala
 pymongo==4.1.0
     # via kytos
@@ -188,16 +209,19 @@ pyparsing==3.0.6
 pytest==7.0.0
     # via
     #   amlight-flow-stats
+    #   pytest-asyncio
     #   pytest-cov
+pytest-asyncio==0.18.3
+    # via -r requirements/dev.in
 pytest-cov==3.0.0
     # via amlight-flow-stats
-python-daemon==2.2.4
+python-daemon==2.3.1
     # via kytos
-python-engineio==3.12.1
+python-engineio==4.3.4
     # via
     #   kytos
     #   python-socketio
-python-socketio==4.5.1
+python-socketio==5.7.1
     # via
     #   flask-socketio
     #   kytos
@@ -205,35 +229,40 @@ requests==2.27.0
     # via amlight-sdntrace
 six==1.16.0
     # via
+    #   asttokens
     #   flask-cors
     #   kytos
-    #   python-engineio
-    #   python-socketio
     #   tox
-    #   traitlets
     #   virtualenv
+stack-data==0.5.0
+    # via
+    #   ipython
+    #   kytos
 tenacity==8.0.1
     # via kytos
 toml==0.10.2
-    # via
-    #   pylint
-    #   tox
+    # via tox
 tomli==1.2.3
     # via
     #   black
     #   coverage
     #   pep517
+    #   pylint
     #   pytest
+tomlkit==0.11.4
+    # via pylint
 tox==3.24.5
     # via amlight-flow-stats
-traitlets==4.3.3
+traitlets==5.3.0
     # via
     #   ipython
     #   kytos
-typing-extensions==4.0.1
+    #   matplotlib-inline
+typing-extensions>=4.0.1
     # via
     #   astroid
     #   black
+    #   janus
     #   kytos
     #   pydantic
     #   pylint
@@ -245,13 +274,13 @@ urllib3==1.26.7
     #   requests
 virtualenv==20.13.0
     # via tox
-watchdog==0.10.2
+watchdog==2.1.9
     # via kytos
 wcwidth==0.1.9
     # via
     #   kytos
     #   prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.3
     # via
     #   flask
     #   kytos
@@ -261,6 +290,10 @@ wrapt==1.13.3
     # via astroid
 yala==3.1.0
     # via amlight-flow-stats
+zipp==3.8.1
+    # via
+    #   importlib-metadata
+    #   kytos
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@
     # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/sdntrace.git#egg=amlight-sdntrace
     # via -r requirements/dev.in
--e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
     # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
     # via -r requirements/dev.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest conftest."""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def ev_loop(monkeypatch, event_loop) -> None:
+    """asyncio event loop autouse fixture."""
+    monkeypatch.setattr("asyncio.get_running_loop", lambda: event_loop)
+    yield event_loop

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,16 +1,4 @@
 """Module to help to create tests."""
-from unittest.mock import Mock
-
-from kytos.core import Controller
-from kytos.core.config import KytosConfig
-
-
-def get_controller_mock():
-    """Return a controller mock."""
-    options = KytosConfig().options["daemon"]
-    controller = Controller(options)
-    controller.log = Mock()
-    return controller
 
 
 def get_mocked_requests(_):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -290,7 +290,6 @@ class TestMain(TestCase):
 
         return response
 
-    # pylint: disable=no-self-use
     def _get_mocked_flow_stats(self):
         """Helper method to create a mock flow_stats object."""
         flow_stats = MagicMock()


### PR DESCRIPTION
- Ugraded core dev dependencies (they needed to be regenerated). It's related to https://github.com/kytos-ng/kytos/pull/284. 
- I've also upgraded `pylint` and fixed linter errors that showed up. 
- For now, `feature/upgrade_dependencies` kytos branch is pinned just so tests pass in the CI. I'll revert this after before this PR gets merged after review. 