### PR TITLE
Fix error in from_replies_flows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ All notable changes to the flow_stats NApp will be documented in this file.
 Added
 =====
 
+- Added `from_replies_flows`` function to map a the replies_flows into generic flows.
+- Event ``kytos/of_core.flow_stats.received`` has replaced event ``kytos/of_core.v0x04.messages.in.ofpt_multipart_reply``.
+
 Changed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to the flow_stats NApp will be documented in this file.
 Added
 =====
 
-- Added `from_replies_flows`` function to map a the replies_flows into generic flows.
+- Added `from_replies_flows` function to map a the replies_flows into generic flows.
 - Event ``kytos/of_core.flow_stats.received`` has replaced event ``kytos/of_core.v0x04.messages.in.ofpt_multipart_reply``.
 
 Changed

--- a/main.py
+++ b/main.py
@@ -20,7 +20,6 @@ from napps.kytos.of_core.v0x01.flow import Action as Action10
 from napps.kytos.of_core.v0x04.flow import Action as Action13
 from napps.kytos.of_core.v0x04.match_fields import MatchFieldFactory
 from pyof.v0x01.common.flow_match import FlowWildCards
-from pyof.v0x04.common.flow_instructions import InstructionType
 
 
 class GenericFlow():
@@ -193,7 +192,7 @@ class GenericFlow():
             flow.match[field_name] = match_field
         flow.actions = []
         for instruction in flow04.instructions:
-            if instruction.instruction_type == 'apply_actions': 
+            if instruction.instruction_type == 'apply_actions':
                 for of_action in instruction.actions:
                     flow.actions.append(of_action)
         return flow

--- a/main.py
+++ b/main.py
@@ -171,6 +171,36 @@ class GenericFlow():
                         flow.actions.append(action)
         return flow
 
+    @classmethod
+    def from_replies_flows(cls, flow04):
+        """Create a flow from a flow passed on
+        replies_flows in event kytos/of_core.flow_stats.received."""
+
+        flow = GenericFlow(version='0x04')
+        flow.idle_timeout = flow04.idle_timeout
+        flow.hard_timeout = flow04.hard_timeout
+        flow.priority = flow04.priority
+        flow.table_id = flow04.table_id
+        flow.duration_sec = flow04.stats.duration_sec
+        flow.packet_count = flow04.stats.packet_count
+        flow.byte_count = flow04.stats.byte_count
+
+        as_of_match = flow04.match.as_of_match()
+        for match in as_of_match.oxm_match_fields:
+            match_field = MatchFieldFactory.from_of_tlv(match)
+            field_name = match_field.name
+            if field_name == 'dl_vlan':
+                field_name = 'vlan_vid'
+            flow.match[field_name] = match_field
+        flow.actions = []
+        for instruction in flow04.instructions:
+            if instruction.instruction_type == \
+                    InstructionType.OFPIT_APPLY_ACTIONS:
+                for of_action in instruction.actions:
+                    action = Action13.from_of_action(of_action)
+                    flow.actions.append(action)
+        return flow
+
     def do_match(self, args):
         """Match a packet against this flow."""
         if self.version == '0x01':
@@ -281,6 +311,7 @@ class GenericFlow():
         return self
 
 
+# pylint: disable=too-many-public-methods
 class Main(KytosNApp):
     """Main class of amlight/flow_stats NApp.
 
@@ -565,3 +596,25 @@ class Main(KytosNApp):
             event = KytosEvent('amlight/flow_stats.flows_updated')
             event.content['switch'] = switch.dpid
             self.controller.buffers.app.put(event)
+
+    @listen_to('kytos/of_core.flow_stats.received')
+    def on_stats_received(self, event):
+        """Capture flow stats messages for OpenFlow 1.3."""
+        self.handle_stats_received(event)
+
+    def handle_stats_received(self, event):
+        """Handle flow stats messages for OpenFlow 1.3."""
+        switch = event.content['switch']
+        if 'replies_flows' in event.content:
+            replies_flows = event.content['replies_flows']
+            self.handle_stats_reply_received(switch, replies_flows)
+
+    # pylint: disable=no-self-use
+    def handle_stats_reply_received(self, switch, replies_flows):
+        """Iterate on the replies and set the generic flows"""
+        switch.generic_flows = [GenericFlow.from_replies_flows(flow)
+                                for flow in replies_flows]
+        switch.generic_flows.sort(
+                    key=lambda f: (f.priority, f.duration_sec),
+                    reverse=True
+                    )

--- a/main.py
+++ b/main.py
@@ -163,8 +163,7 @@ class GenericFlow():
                 flow.match[field_name] = match_field
             flow.actions = []
             for instruction in flow_stats.instructions:
-                if instruction.instruction_type == \
-                        InstructionType.OFPIT_APPLY_ACTIONS:
+                if instruction.instruction_type == 'apply_actions':
                     for of_action in instruction.actions:
                         action = Action13.from_of_action(of_action)
                         flow.actions.append(action)
@@ -180,6 +179,7 @@ class GenericFlow():
         flow.hard_timeout = flow04.hard_timeout
         flow.priority = flow04.priority
         flow.table_id = flow04.table_id
+        flow.cookie = flow04.cookie
         flow.duration_sec = flow04.stats.duration_sec
         flow.packet_count = flow04.stats.packet_count
         flow.byte_count = flow04.stats.byte_count
@@ -193,11 +193,9 @@ class GenericFlow():
             flow.match[field_name] = match_field
         flow.actions = []
         for instruction in flow04.instructions:
-            if instruction.instruction_type == \
-                    InstructionType.OFPIT_APPLY_ACTIONS:
+            if instruction.instruction_type == 'apply_actions': 
                 for of_action in instruction.actions:
-                    action = Action13.from_of_action(of_action)
-                    flow.actions.append(action)
+                    flow.actions.append(of_action)
         return flow
 
     def do_match(self, args):

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ import json
 from threading import Lock
 
 import pyof.v0x01.controller2switch.common as common01
-import pyof.v0x04.controller2switch.common as common04
 from flask import jsonify, request
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
@@ -551,18 +550,6 @@ class Main(KytosNApp):
         """Handle stats replies for v0x01 switches."""
         msg = event.content['message']
         if msg.body_type == common01.StatsType.OFPST_FLOW:
-            switch = event.source.switch
-            self.handle_stats_reply(msg, switch)
-
-    @listen_to('kytos/of_core.v0x04.messages.in.ofpt_multipart_reply')
-    def on_stats_reply_0x04(self, event):
-        """Capture flow stats messages for OpenFlow 1.3."""
-        self.handle_stats_reply_0x04(event)
-
-    def handle_stats_reply_0x04(self, event):
-        """Handle flow stats messages for OpenFlow 1.3."""
-        msg = event.content['message']
-        if msg.multipart_type == common04.MultipartType.OFPMP_FLOW:
             switch = event.source.switch
             self.handle_stats_reply(msg, switch)
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -18,7 +18,6 @@ from napps.kytos.of_core.v0x04.match_fields import (
 from pyof.foundation.basic_types import UBInt32
 from pyof.v0x04.common.flow_instructions import InstructionType
 from pyof.v0x01.controller2switch.common import StatsType
-from pyof.v0x04.controller2switch.common import MultipartType
 
 
 # pylint: disable=too-many-public-methods, too-many-lines
@@ -382,44 +381,6 @@ class TestMain(TestCase):
         event = get_kytos_event_mock(name=name, content=content)
 
         self.napp.handle_stats_reply_0x01(event)
-
-        mock_handle_stats.assert_not_called()
-
-    @patch("napps.amlight.flow_stats.main.Main.handle_stats_reply")
-    def test_handle_stats_reply_0x04(self, mock_handle_stats):
-        """Test handle stats reply."""
-        flow_msg = MagicMock()
-        flow_msg.body = "A"
-        flow_msg.multipart_type = MultipartType.OFPMP_FLOW
-
-        switch_v0x04 = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
-
-        name = "kytos/of_core.v0x04.messages.in.ofpt_multipart_reply"
-        content = {"source": switch_v0x04.connection, "message": flow_msg}
-        event = get_kytos_event_mock(name=name, content=content)
-        event.content["message"] = flow_msg
-
-        self.napp.handle_stats_reply_0x04(event)
-
-        mock_handle_stats.assert_called_once()
-
-    @patch("napps.amlight.flow_stats.main.Main.handle_stats_reply")
-    def test_handle_stats_reply_0x04_fail(self, mock_handle_stats):
-        """Test handle stats reply."""
-        flow_msg = MagicMock()
-        flow_msg.body = "A"
-
-        flow_msg.multipart_type = MultipartType.OFPMP_PORT_DESC
-
-        switch_v0x04 = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
-
-        name = "kytos/of_core.v0x04.messages.in.ofpt_multipart_reply"
-        content = {"source": switch_v0x04.connection, "message": flow_msg}
-
-        event = get_kytos_event_mock(name=name, content=content)
-        event.content["message"] = flow_msg
-
-        self.napp.handle_stats_reply_0x04(event)
 
         mock_handle_stats.assert_not_called()
 


### PR DESCRIPTION
Fix #21 

This is a new PR to deal with the kytos/of_core.flow_stats.received event for OF 0x04, 
Function 'handle_stats_received' has been added, that looks for 'replies_flows' in the event content, iterates through it, and sets the generic flows.
Function 'from_replies_flows' has also been added, which maps Flow from v0x04 into GenericFlow.

Testing locally, I have used a linear net of 3 switches. I could see into the controller in kytos for the switch '00:00:00:00:00:00:00:01':
```
{'dpid': '00:00:00:00:00:00:00:01',
 'connection': Connection('127.0.0.1', 44186, <asyncio.TransportSocket fd=111, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 44186)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2>),
 'features': FeaturesReply(xid=UBInt32(361952766)),
 'firstseen': datetime.datetime(2022, 9, 13, 2, 40, 47, 377716, tzinfo=datetime.timezone.utc),
 'lastseen': datetime.datetime(2022, 9, 13, 2, 47, 50, 57016, tzinfo=datetime.timezone.utc),
 'sent_xid': None,
 'waiting_for_reply': False,
 'request_timestamp': 0,
 'mac2port': {},
 'flood_table': {},
 'interfaces': {4294967294: Interface('s1', 4294967294, Switch('00:00:00:00:00:00:00:01')),
  1: Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01')),
  2: Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))},
 'flows': [<napps.kytos.of_core.v0x04.flow.Flow at 0x7fd1a42e7190>,
  <napps.kytos.of_core.v0x04.flow.Flow at 0x7fd1a42f4550>,
  <napps.kytos.of_core.v0x04.flow.Flow at 0x7fd1a42f4370>],
 'description': {'manufacturer': 'Nicira, Inc.',
  'hardware': 'Open vSwitch',
  'software': '2.9.8',
  'serial': 'None',
  'data_path': 'None'},
 '_id': '00:00:00:00:00:00:00:01',
 '_interface_lock': <unlocked _thread.lock object at 0x7fd230022300>,
 'metadata': {},
 '_active': True,
 '_enabled': True,
 'generic_flows': [<napps.amlight.flow_stats.main.GenericFlow at 0x7fd1a45e7df0>,
  <napps.amlight.flow_stats.main.GenericFlow at 0x7fd234ed4220>,
  <napps.amlight.flow_stats.main.GenericFlow at 0x7fd1a42dd8b0>],
 'generic_new_flows': [<napps.amlight.flow_stats.main.GenericFlow at 0x7fd1a45e7df0>,
  <napps.amlight.flow_stats.main.GenericFlow at 0x7fd234ed4220>,
  <napps.amlight.flow_stats.main.GenericFlow at 0x7fd1a42dd8b0>]}

 Moreover, I saw the traces with sdntrace_cp:

{
    "result": [
        {
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 1,
            "time": "2022-09-12 21:09:55.023383",
            "type": "starting",
            "vlan": 100
        },
        {
            "dpid": "00:00:00:00:00:00:00:02",
            "port": 2,
            "time": "2022-09-12 21:09:55.023432",
            "type": "trace",
            "vlan": 3366
        },
        {
            "dpid": "00:00:00:00:00:00:00:03",
            "port": 2,
            "time": "2022-09-12 21:09:55.023464",
            "type": "trace",
            "vlan": 2344
        }
    ]
}
```
However, I wonder if these traces correspond to event 'kytos/of_core.v0x04.messages.in.ofpt_multipart_reply'