### PR TITLE
Drop GenericFlow abstraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ class Main(KytosNApp):
         So, if you have any setup routine, insert it here.
         """
         log.info('Starting Kytos/Amlight flow manager')
-        self.switch_stats_xid = {}
-        self.switch_stats_lock = {}
+        for switch in self.controller.switches.copy().values():
+            switch.stat_flows = []
 
     def execute(self):
         """This method is executed right after the setup method execution.
@@ -55,7 +55,7 @@ class Main(KytosNApp):
         """Flow from given flow_id."""
         for switch in self.controller.switches.copy().values():
             try:
-                for flow in switch.flows: 
+                for flow in switch.stat_flows: 
                     if flow.id == flow_id:
                         return flow
             except KeyError:
@@ -96,7 +96,7 @@ class Main(KytosNApp):
         """
         response = []
         try:
-            for flow in switch.flows: 
+            for flow in switch.stat_flows: 
                 match = flow.do_match(args)
                 if match:
                     if many:
@@ -220,7 +220,7 @@ class Main(KytosNApp):
 
         # We don't have statistics persistence yet, so for now this only works
         # for start and end equals to zero
-        flows = self.controller.get_switch_by_dpid(dpid).flows 
+        flows = self.controller.get_switch_by_dpid(dpid).stat_flows 
 
         for flow in flows:
             count = getattr(flow, field)
@@ -250,8 +250,8 @@ class Main(KytosNApp):
 
     def handle_stats_reply_received(self, switch, replies_flows):
         """Iterate on the replies and set the list of flows"""
-        switch.flows = replies_flows
-        switch.flows.sort(
+        switch.stat_flows = replies_flows
+        switch.stat_flows.sort(
                     key=lambda f: (f.priority, f.stats.duration_sec),
                     reverse=True
                     )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -8,8 +8,9 @@ from kytos.lib.helpers import (
     get_kytos_event_mock,
     get_switch_mock,
 )
-from napps.amlight.flow_stats.main import GenericFlow, Main
+from napps.amlight.flow_stats.main import Main
 from napps.kytos.of_core.v0x04.flow import Action as Action40
+from napps.kytos.of_core.v0x04.flow import Flow as Flow40
 from napps.kytos.of_core.v0x04.match_fields import MatchFieldFactory
 from napps.kytos.of_core.v0x04.flow import Match as Match40
 from pyof.foundation.basic_types import UBInt32
@@ -195,7 +196,7 @@ class TestMain(TestCase):
     @patch("napps.amlight.flow_stats.main.Main.match_flows")
     def test_flow_match(self, mock_match_flows):
         """Test flow_match rest call."""
-        flow = GenericFlow()
+        flow = Flow40()
         flow.actions = [
             Action40.from_dict(
                 {
@@ -237,7 +238,7 @@ class TestMain(TestCase):
     @patch("napps.amlight.flow_stats.main.Main.match_flows")
     def test_flow_stats(self, mock_match_flows):
         """Test flow_match rest call."""
-        flow = GenericFlow()
+        flow = Flow40()
         flow.actions = [
             Action40.from_dict(
                 {
@@ -270,7 +271,7 @@ class TestMain(TestCase):
         flow = self._get_mocked_flow_stats()
         flow.id = flow_id
         switch = MagicMock()
-        switch.generic_flows = [flow]
+        switch.flows = [flow]
         self.napp.controller.switches = {"1": switch}
         self.napp.controller.get_switch_by_dpid = MagicMock()
         self.napp.controller.get_switch_by_dpid.return_value = switch
@@ -318,33 +319,6 @@ class TestMain(TestCase):
         flow.stats = self._get_mocked_flow_stats()
         return flow
 
-    @patch("napps.amlight.flow_stats.main.GenericFlow.from_flow_stats")
-    def test_handle_stats_reply(self, mock_from_flow):
-        """Test handle_stats_reply rest call."""
-        mock_from_flow.return_value = self._get_mocked_flow_base()
-
-        def side_effect(event):
-            self.assertTrue(f"{event}", "amlight/flow_stats.flows_updated")
-            self.assertTrue(event.content["switch"], 111)
-
-        self.napp.controller = MagicMock()
-        self.napp.controller.buffers.app.put.side_effect = side_effect
-
-        msg = MagicMock()
-        msg.flags.value = 2
-        msg.body = [self._get_mocked_flow_stats()]
-        event_switch = MagicMock()
-        event_switch.generic_flows = []
-        event_switch.dpid = 111
-        self.napp.handle_stats_reply(msg, event_switch)
-
-        # Check if important trace dont trigger the event
-        # It means that the CP trace is the same to the DP trace
-        self.napp.controller.buffers.app.put.assert_called_once()
-
-        # Check mocked flow id
-        self.assertEqual(event_switch.generic_flows[0].id, 456)
-
     @patch("napps.amlight.flow_stats.main.Main.handle_stats_reply_received")
     def test_handle_stats_received(self, mock_handle_stats):
         """Test handle_stats_received function."""
@@ -373,148 +347,10 @@ class TestMain(TestCase):
         self.napp.handle_stats_received(event)
         mock_handle_stats.assert_not_called()
 
-    @patch("napps.amlight.flow_stats.main.GenericFlow.from_replies_flows")
     def test_handle_stats_reply_received(self, mock_from_flow):
         """Test handle_stats_reply_received call."""
-        mock_from_flow.return_value = self._get_mocked_flow_base()
-
         event_switch = MagicMock()
         flows_mock = self._get_mocked_multipart_replies_flows()
         self.napp.handle_stats_reply_received(event_switch, flows_mock)
 
-        self.assertEqual(event_switch.generic_flows[0].id, 456)
-
-
-# pylint: disable=too-many-public-methods, too-many-lines
-class TestGenericFlow(TestCase):
-    """Test the GenericFlow class."""
-
-    # pylint: disable=no-member
-    def test_from_flow_stats__x04(self):
-        """Test from_flow_stats method 0x04 version."""
-        flow_stats = MagicMock()
-
-        flow_stats.actions = [
-            Action40.from_dict(
-                {
-                    "action_type": "output",
-                    "port": UBInt32(1),
-                }
-            ).as_of_action(),
-        ]
-
-        result = GenericFlow.from_flow_stats(flow_stats)
-
-        self.assertEqual(result.idle_timeout, flow_stats.idle_timeout.value)
-        self.assertEqual(result.hard_timeout, flow_stats.hard_timeout.value)
-        self.assertEqual(result.priority, flow_stats.priority.value)
-        self.assertEqual(result.table_id, flow_stats.table_id.value)
-        self.assertEqual(result.duration_sec, flow_stats.duration_sec.value)
-        self.assertEqual(result.packet_count, flow_stats.packet_count.value)
-        self.assertEqual(result.byte_count, flow_stats.byte_count.value)
-        self.assertEqual(result.version, "0x04")
-
-    def test_from_replies_flows(self):
-        """Test from_replies_flows method 0x04 version."""
-        replies_flow = MagicMock()
-
-        action_dict = {
-            "action_type": "output",
-            "port": UBInt32(1),
-        }
-
-        actions = Action40.from_dict(action_dict).as_of_action()
-
-        instruction = MagicMock()
-        instruction.instruction_type = 'apply_actions'
-        instruction.actions = [actions]
-        replies_flow.instructions = [instruction]
-        match = Match40(42)
-        replies_flow.match = match
-        result = GenericFlow.from_replies_flows(replies_flow)
-
-        self.assertEqual(result.idle_timeout, replies_flow.idle_timeout)
-        self.assertEqual(result.hard_timeout, replies_flow.hard_timeout)
-        self.assertEqual(result.priority, replies_flow.priority)
-        self.assertEqual(result.table_id, replies_flow.table_id)
-        self.assertEqual(result.cookie, replies_flow.cookie)
-        self.assertEqual(result.duration_sec, replies_flow.stats.duration_sec)
-        self.assertEqual(result.packet_count, replies_flow.stats.packet_count)
-        self.assertEqual(result.byte_count, replies_flow.stats.byte_count)
-
-        # pylint: disable=too-many-public-methods, too-many-lines
-        match_expect = MatchFieldFactory.from_of_tlv(
-            match.as_of_match().oxm_match_fields[0]
-            )
-        self.assertEqual(result.actions[0], actions)
-        self.assertEqual(result.match["in_port"], match_expect)
-
-    def test_to_dict__x04(self):
-        """Test to_dict method 0x04 version."""
-        match = {}
-        match["in_port"] = MagicMock()
-        match["in_port"].value = 22
-
-        generic_flow = GenericFlow(
-            version="0x04",
-            match=match,
-        )
-
-        result = generic_flow.to_dict()
-        expected = {
-            "version": "0x04",
-            "in_port": 22,
-            "idle_timeout": 0,
-            "hard_timeout": 0,
-            "priority": 0,
-            "table_id": 255,
-            "cookie": None,
-            "buffer_id": None,
-            "actions": [],
-        }
-
-        self.assertEqual(result, expected)
-
-    def test_match_to_dict(self):
-        """Test match_to_dict method for 0x04 version."""
-        match = {}
-        match["in_port"] = MagicMock()
-        match["in_port"].value = 22
-        match["vlan_vid"] = MagicMock()
-        match["vlan_vid"].value = 123
-
-        generic_flow = GenericFlow(
-            version="0x04",
-            match=match,
-        )
-        result = generic_flow.match_to_dict()
-        expected = {"in_port": 22, "vlan_vid": 123}
-
-        self.assertEqual(result, expected)
-
-    def test_match_to_dict__empty_match(self):
-        """Test match_to_dict method for 0x04 version, with empty matches."""
-        generic_flow = GenericFlow(version="0x04")
-        result = generic_flow.match_to_dict()
-        self.assertEqual(result, {})
-
-    def test_id__x04(self):
-        """Test id method 0x04 version."""
-        match = {}
-        match["in_port"] = MagicMock()
-        match["in_port"].value = 22
-        match["vlan_vid"] = MagicMock()
-        match["vlan_vid"].value = 123
-
-        generic_flow = GenericFlow(
-            version="0x04",
-            match=match,
-            idle_timeout=1,
-            hard_timeout=2,
-            priority=6,
-            table_id=7,
-            cookie=8,
-            buffer_id=9,
-        )
-
-        self.assertEqual(generic_flow.id, "2d843f76b8b254fad6c6e2a114590440")
+        self.assertEqual(event_switch.flows[0].id, 456)


### PR DESCRIPTION
Fix #35 

GenericFlow abstraction has been removed. Next, you can see that the generic_flow field no longer appears in the switch.

kytos $> controller.switches['00:00:00:00:00:00:00:01'].__dict__                                                                                                                                            
Out[1]: 
{'dpid': '00:00:00:00:00:00:00:01',
 'connection': Connection('127.0.0.1', 41112, <asyncio.TransportSocket fd=113, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 6653), raddr=('127.0.0.1', 41112)>, Switch('00:00:00:00:00:00:00:01'), <ConnectionState.ESTABLISHED: 2>),
 'features': FeaturesReply(xid=UBInt32(3299854305)),
 'firstseen': datetime.datetime(2022, 9, 22, 19, 5, 38, 340837, tzinfo=datetime.timezone.utc),
 'lastseen': datetime.datetime(2022, 9, 22, 19, 6, 5, 869563, tzinfo=datetime.timezone.utc),
 'sent_xid': None,
 'waiting_for_reply': False,
 'request_timestamp': 0,
 'mac2port': {},
 'flood_table': {},
 'interfaces': {4294967294: Interface('s1', 4294967294, Switch('00:00:00:00:00:00:00:01')),
  1: Interface('s1-eth1', 1, Switch('00:00:00:00:00:00:00:01')),
  2: Interface('s1-eth2', 2, Switch('00:00:00:00:00:00:00:01'))},
 'flows': [<napps.kytos.of_core.v0x04.flow.Flow at 0x7f916150cdf0>,
  <napps.kytos.of_core.v0x04.flow.Flow at 0x7f916150c3a0>,
  <napps.kytos.of_core.v0x04.flow.Flow at 0x7f916150c3d0>],
 'description': {'manufacturer': 'Nicira, Inc.',
  'hardware': 'Open vSwitch',
  'software': '2.9.8',
  'serial': 'None',
  'data_path': 'None'},
 '_id': '00:00:00:00:00:00:00:01',
 '_interface_lock': <unlocked _thread.lock object at 0x7f920c1d41b0>,
 'metadata': {},
 '_active': True,
 '_enabled': True}
