### PR TITLE
feature: Add table stats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,15 @@
 #########
 Changelog
 #########
-All notable changes to the flow_stats NApp will be documented in this file.
+All notable changes to the kytos_stats NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
 Added
 =====
+- Event ``kytos/of_core.table_stats.received``.
+- Update `scripts/kytos_zabbix.py` script to add table stats.
+- Add GET ``v1/table/stats`` endpoint to listing table stats by dpid.
 
 Changed
 =======
@@ -25,61 +28,5 @@ Security
 
 General Information
 ===================
-- ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
-
-
-[2022.3.0] - 2023-01-23
-***********************
-
-Added
-=====
-
-- Added `from_replies_flows` function to map a the replies_flows into generic flows.
-- Event ``kytos/of_core.flow_stats.received`` has replaced event ``kytos/of_core.v0x04.messages.in.ofpt_multipart_reply``.
-- Added `scripts/kytos_zabbix.py` script to demonstrate how Kytos can be monitored through Zabbix.
-
-Changed
-=======
-
-- Update GET ``v1/flow/stats`` endpoint to listing flow stats by dpid.
-- v1 is bumped on endpoint routes: GET ``v1/flow/stats``, GET ``v1/packet_count/<flow_id>``, GET ``v1/bytes_count/<flow_id>``, GET ``v1/packet_count/per_flow/<dpid>``, GET ``v1/bytes_count/per_flow/<dpid>``
-
-Removed
-=======
-- Removed support for OpenFlow 1.0
-- `GenericFlow` abstraction
-- GET ``flow/match/<dpid>`` endpoint
-- GET ``packet_count/sum/{{dpid}}`` endpoint
-- GET ``bytes_count/sum/{{dpid}}`` endpoint
-
-
-[2022.2.1] - 2022-08-15
-***********************
-
-Fixed
-=====
-- Made a shallow copy when iterating on shared data structure to avoid RuntimeError size changed
-
-
-[2022.2.0] - 2022-08-08
-***********************
-
-General Information
-===================
-- Added unit tests and increased unit test coverage
-
-
-[2022.1.0] - 2022-02-08
-***********************
-
-Added
-=====
-- [Issue 12] Enhanced and standardized setup.py `install_requires` to install pinned dependencies
-- [Issue 4] Add setup.py and requirements
-- [Issue 9] Improve flow_stats handler to avoid reset generic_flows before having all multiple parts
-
-Fixed
-=====
-- [Issue 13] GET /api/amlight/flow_stats/flow/stats/ not found
-- [Issue 8] Fix multipart flow stats reply to avoid data loss and race conditions
-- [Issue 5] Removing flow_history from flow_stats as a result of performance issues
+- This napp was cloned from ``flow_stats``.
+- ``@rest`` endpoints run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.

--- a/README.rst
+++ b/README.rst
@@ -3,17 +3,17 @@
 .. raw:: html
 
   <div align="center">
-    <h1><code>amlight/flow_stats</code></h1>
+    <h1><code>amlight/kytos_stats</code></h1>
 
-    <strong> Napp responsible for providing flows statistics. </strong>
+    <strong> Napp responsible for providing statistics. </strong>
 
-    <h3><a href="https://kytos-ng.github.io/api/flow_stats.html">OpenAPI Docs</a></h3>
+    <h3><a href="https://kytos-ng.github.io/api/kytos_stats.html">OpenAPI Docs</a></h3>
   </div>
 
 
 Overview
 ========
-Napp responsible for providing flows statistics.
+Napp responsible for providing statistics.
 
 Installing
 ========== 
@@ -22,16 +22,18 @@ To install this NApp, first, make sure to have the same venv activated as you ha
 
 .. code:: shell
 
-   $ git clone https://github.com/amlight/flow_stats.git
-   $ cd flow_stats
+   $ git clone https://github.com/amlight/kytos_stats.git
+   $ cd kytos_stats
    $ python setup.py develop
 
 Features
 ========
 - REST API to list flows statistics by switch
+- REST API to list tables statistics by switch
 - REST API to get flows statistics (packet_count and bytes_count) of an specific flow
 - REST API to get flows statistics (packet_count and bytes_count) for a switch
 - Handle flow stats messages when replies are received
+- Handle table stats messages when replies are received
 
 Requirements
 ============
@@ -45,25 +47,26 @@ Subscribed
 ----------
 
 - ``kytos/of_core.flow_stats.received``
+- ``kytos/of_core.table_stats.received``
 
 
 .. TAGs
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
-   :target: https://github.com/amlight/flow_stats
-.. |License| image:: https://img.shields.io/github/license/amlight/flow_stats.svg
-   :target: https://github.com/amlight/flow_stats/blob/master/LICENSE
-.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/badges/build.png?b=master
+   :target: https://github.com/amlight/kytos_stats
+.. |License| image:: https://img.shields.io/github/license/amlight/kytos_stats.svg
+   :target: https://github.com/amlight/kytos_stats/blob/master/LICENSE
+.. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/build.png?b=master
   :alt: Build status
-  :target: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/?branch=master
-.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/badges/coverage.png?b=master
+  :target: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/?branch=master
+.. |Coverage| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/coverage.png?b=master
   :alt: Code coverage
-  :target: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/?branch=master
-.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/badges/quality-score.png?b=master
+  :target: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/?branch=master
+.. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/quality-score.png?b=master
   :alt: Code-quality score
-  :target: https://scrutinizer-ci.com/g/kytos-ng/flow_stats/?branch=master
-.. |Tag| image:: https://img.shields.io/github/tag/amlight/flow_stats.svg
-   :target: https://github.com/kytos-ng/flow_stats/tags
+  :target: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/?branch=master
+.. |Tag| image:: https://img.shields.io/github/tag/amlight/kytos_stats.svg
+   :target: https://github.com/kytos-ng/kytos_stats/tags
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,9 @@ Subscribed
 .. TAGs
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
-   :target: https://github.com/amlight/kytos_stats
+   :target: https://github.com/kytos-ng/kytos_stats
 .. |License| image:: https://img.shields.io/github/license/amlight/kytos_stats.svg
-   :target: https://github.com/amlight/kytos_stats/blob/master/LICENSE
+   :target: https://github.com/kytos-ng/kytos_stats/blob/master/LICENSE
 .. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/build.png?b=master
   :alt: Build status
   :target: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/?branch=master

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Subscribed
 
 .. |Stable| image:: https://img.shields.io/badge/stability-stable-green.svg
    :target: https://github.com/kytos-ng/kytos_stats
-.. |License| image:: https://img.shields.io/github/license/amlight/kytos_stats.svg
+.. |License| image:: https://img.shields.io/github/license/kytos-ng/kytos_stats.svg
    :target: https://github.com/kytos-ng/kytos_stats/blob/master/LICENSE
 .. |Build| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/build.png?b=master
   :alt: Build status
@@ -65,7 +65,7 @@ Subscribed
 .. |Quality| image:: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/badges/quality-score.png?b=master
   :alt: Code-quality score
   :target: https://scrutinizer-ci.com/g/kytos-ng/kytos_stats/?branch=master
-.. |Tag| image:: https://img.shields.io/github/tag/amlight/kytos_stats.svg
+.. |Tag| image:: https://img.shields.io/github/tag/kytos-ng/kytos_stats.svg
    :target: https://github.com/kytos-ng/kytos_stats/tags
 
 

--- a/kytos.json
+++ b/kytos.json
@@ -1,11 +1,11 @@
 {
   "author": "amlight",
   "username": "amlight",
-  "name": "flow_stats",
-  "description": "Store flow information and show statistics about them.",
-  "version": "2022.3.0",
+  "name": "kytos_stats",
+  "description": "Show statistics about flows and tables.",
+  "version": "2023.1.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "",
   "tags": [],
-  "url": "https://github.com/kytos-ng/flow_stats"
+  "url": "https://github.com/kytos-ng/kytos_stats"
 }

--- a/main.py
+++ b/main.py
@@ -64,17 +64,17 @@ class Main(KytosNApp):
         """
         table_stats_by_id = {}
         tables_stats_dict_copy = self.tables_stats_dict.copy()
-        for dpid_dict, tables in tables_stats_dict_copy.items():
-            if dpid_dict not in dpids:
+        for dpid, tables in tables_stats_dict_copy.items():
+            if dpid not in dpids:
                 continue
-            table_stats_by_id[dpid_dict] = {}
+            table_stats_by_id[dpid] = {}
             if len(table_ids) == 0:
                 table_ids = list(tables.keys())
-            for _id, table in tables.items():
-                if _id in table_ids:
+            for table_id, table in tables.items():
+                if table_id in table_ids:
                     table_dict = table.as_dict()
                     del table_dict['switch']
-                    table_stats_by_id[dpid_dict].update({_id: table_dict})
+                    table_stats_by_id[dpid][table_id] = table_dict
         return table_stats_by_id
 
     @rest('v1/flow/stats')
@@ -206,9 +206,8 @@ class Main(KytosNApp):
 
     def handle_table_stats_received(self, event):
         """Handle table stats messages for OpenFlow 1.3."""
-        if 'replies_tables' in event.content:
-            replies_tables = event.content['replies_tables']
-            self.handle_table_stats_reply_received(replies_tables)
+        replies_tables = event.content['replies_tables']
+        self.handle_table_stats_reply_received(replies_tables)
 
     def handle_table_stats_reply_received(self, replies_tables):
         """Update the set of tables stats"""

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,10 +1,10 @@
 openapi: 3.0.0
 info:
-  title: amlight/flow_stats
+  title: amlight/kytos_stats
   version: v1
   description: Flow structures and statistics
 paths:
-  /api/amlight/flow_stats/v1/flow/stats:
+  /api/amlight/kytos_stats/v1/flow/stats:
     get:
       tags:
         - object
@@ -63,7 +63,62 @@ paths:
                             example: 32768
                           match:
                             type: object
-  /api/amlight/flow_stats/v1/packet_count/{flow_id}:
+  /api/amlight/kytos_stats/v1/table/stats:
+    get:
+      tags:
+        - object
+      summary: Return table stats.
+      description: Return the stats of tables given a list of dpids and optionally table_id.
+      parameters:  
+        - name: dpid
+          schema:
+            type: array
+            items:
+              type: string
+          description: List of switch ids
+          required: false
+          in: query
+          example: ["00:00:00:00:00:00:00:01","00:00:00:00:00:00:00:02"]  
+        - name: table
+          schema:
+            type: array
+            items:
+              type: string
+          description: List of table ids
+          required: false
+          in: query
+          example: ["0", "1"]  
+      responses:
+        200:  
+          description: Describe a successful call.
+          content:
+            application/json:  
+              schema:
+                type: object
+                properties:
+                  switch: 
+                    type: object
+                    properties:
+                      table:
+                        type: object
+                        properties:
+                          table_id:
+                            type: integer
+                            format: int8
+                            example: 0
+                          active_count:
+                            type: integer
+                            format: int32
+                            example: 0
+                          lookup_count:
+                            type: integer
+                            format: int64
+                            example: 0
+                          matched_count:
+                            type: integer
+                            format: int64
+                            example: 0
+  /api/amlight/kytos_stats/v1/packet_count/{flow_id}:
     get:
       summary: Packet count of an specific flow.
       description: Counters of a flow.
@@ -101,7 +156,7 @@ paths:
               schema:
                 type: string
                 example: Flow not found
-  /api/amlight/flow_stats/v1/bytes_count/{flow_id}:
+  /api/amlight/kytos_stats/v1/bytes_count/{flow_id}:
     get:
       summary: Bytes count of an specific flow.
       description: Counter per byte of a flow.
@@ -139,7 +194,7 @@ paths:
               schema:
                 type: string
                 example: Flow not found
-  /api/amlight/flow_stats/v1/packet_count/per_flow/{dpid}:
+  /api/amlight/kytos_stats/v1/packet_count/per_flow/{dpid}:
     get:
       summary: Per flow packet count.
       description: Packet count per flow of a switch
@@ -179,7 +234,7 @@ paths:
               schema:
                 type: string
                 example: Switch not found
-  /api/amlight/flow_stats/v1/bytes_count/per_flow/{dpid}:
+  /api/amlight/kytos_stats/v1/bytes_count/per_flow/{dpid}:
     get:
       summary: Per flow bytes count.
       description: Bytes count per flow of a switch

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ optional arguments:
   -o {1,2,3,4,5,6}, --monitoring_option {1,2,3,4,5,6}
                         Monitoring option: 1 - for monitor nodes, 2 - for
                         monitor links, 3 - for monitor evcs (status), 4 - evc
-                        statistics, 5 - OpenFlow flows stats, 5 - OpenFlow tables stats
+                        statistics, 5 - OpenFlow flows stats, 6 - OpenFlow tables stats
   -t TARGET, --target TARGET
                         Item status (0-down/others, 1-disabled, 2-up/primary,
                         3-up/backup). Argument is the item id to be monitored

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
-## Flow_stats's scripts
+## Kytos_stats's scripts
 
-This folder contains Flow_stats's related scripts.
+This folder contains Kytos_stats's related scripts.
 
 ### Integration Kytos-ng and Zabbix for Monitoring
 
@@ -9,7 +9,7 @@ This folder contains Flow_stats's related scripts.
 #### Pre-requisites
 
 - There's no additional Python libraries dependencies required (the libs we use are usually installed by default).
-- Make sure your Kytos server is running and allowing requests on the Napp `flow_stats`, `mef_eline` and `topology` (via HTTP GET method).
+- Make sure your Kytos server is running and allowing requests on the Napp `kytos_stats`, `mef_eline` and `topology` (via HTTP GET method).
 - When using authentication (recommended), you will have three options to provide the credentials: via command line parameters (unsafe) `--user` and `--pass`; via a file in the filesystem (`--passfile`) which contains the username in the first line and the password in the second line (you can change the permissions of the file to restrict access); via environment variables, such as:
 - Export  related variables that [kytos_zabbix.py](scripts/kytos_zabbix.py) optionally uses
 
@@ -49,10 +49,10 @@ optional arguments:
   -c CACHE_POLICY, --cache_policy CACHE_POLICY
                         Cache policy: never, always or X seconds (default to
                         cache for 600 seconds)
-  -o {1,2,3,4,5}, --monitoring_option {1,2,3,4,5}
+  -o {1,2,3,4,5,6}, --monitoring_option {1,2,3,4,5,6}
                         Monitoring option: 1 - for monitor nodes, 2 - for
                         monitor links, 3 - for monitor evcs (status), 4 - evc
-                        statistics, 5 - OpenFlow flows stats
+                        statistics, 5 - OpenFlow flows stats, 5 - OpenFlow tables stats
   -t TARGET, --target TARGET
                         Item status (0-down/others, 1-disabled, 2-up/primary,
                         3-up/backup). Argument is the item id to be monitored

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 linters=pylint,pycodestyle,isort
-pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass,attribute-defined-outside-init --ignored-modules=napps.amlight.flow_stats,napps.amlight.sdntrace,napps.kytos.of_core
+pylint args = --disable=too-few-public-methods,too-many-instance-attributes,no-name-in-module,unnecessary-pass,attribute-defined-outside-init --ignored-modules=napps.amlight.kytos_stats,napps.amlight.sdntrace,napps.kytos.of_core
 
 [pydocstyle]
 add-ignore = D105,D107

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 # Paths setup with virtualenv detection
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
-NAPP_NAME = 'flow_stats'
+NAPP_NAME = 'kytos_stats'
 NAPP_USERNAME = 'amlight'
 
 # Kytos var folder
@@ -266,8 +266,8 @@ def read_requirements(path="requirements/run.txt"):
 
 setup(name=f'{NAPP_USERNAME}_{NAPP_NAME}',
       version=read_version_from_json(),
-      description='Store flow information and show statistics about them.',
-      url='http://github.com/kytos-ng/flow_stats',
+      description='Show statistics about flows and tables.',
+      url='http://github.com/kytos-ng/kytos_stats',
       author='FIU/AmLight team',
       author_email='ops@amlight.net',
       license='MIT',

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,7 @@
 """Module to test the utils.py file."""
 from unittest import TestCase
 
-from napps.amlight.flow_stats.utils import (
+from napps.amlight.kytos_stats.utils import (
     IPv4AddressWithMask, IPv6AddressWithMask)
 
 


### PR DESCRIPTION
Closes #53 

### Summary

- This napp was forked from `flow_stats`.
- Treatment for flow stats is kept.
- This napp is subscribed to the new event: `kytos/of_core.table_stats.received`
- Add `GET v1/table/stats` endpoint to get the statistics of tables and provide query parameters filtering by `dpid` and optionally by `table_id`.
- Unit test were updated (92% cov).

### Local Tests

I made sure `kytos_stats` is loaded correctly and there are no errors:

```
2023-05-13 01:53:09,919 - INFO [kytos.core.controller] (MainThread) Loading NApp amlight/kytos_stats
2023-05-13 01:53:09,974 - INFO [kytos.napps.amlight/kytos_stats] (MainThread) Starting Kytos/Amlight flow manager
2023-05-13 01:53:09,975 - INFO [kytos.core.napps.base] (kytos_stats) Running NApp: <Main(kytos_stats, started 140509766379264)>
2023-05-13 01:53:09,979 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/flow/stats - GET
2023-05-13 01:53:09,980 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/table/stats - GET
2023-05-13 01:53:09,980 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/packet_count/{flow_id} - GET
2023-05-13 01:53:09,981 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/bytes_count/{flow_id} - GET
2023-05-13 01:53:09,982 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/packet_count/per_flow/{dpid} - GET
2023-05-13 01:53:09,982 - INFO [kytos.core.api_server] (MainThread) Started /api/amlight/kytos_stats/v1/bytes_count/per_flow/{dpid} - GET
```
New endpoint:
```
http://127.0.0.1:8181/api/amlight/kytos_stats/v1/table/stats?dpid=00:00:00:00:00:00:00:01&table=0
{
    "00:00:00:00:00:00:00:01": {
        "0": {
            "table_id": 0,
            "active_count": 27,
            "lookup_count": 3246,
            "matched_count": 3202
        }
    }
}
```


### End-to-End Tests

Progress..