### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,9 +23,18 @@ Fixed
 Security
 ========
 
+[2023.1.0] - 2023-06-27
+***********************
+
 General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
+
+
+Deprecated
+==========
+
+- After version ``2023.1``, you should migrate to ``kytos_stats``. This is the last major version that ``flow_stats`` will be maintained.
 
 
 [2022.3.0] - 2023-01-23

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "flow_stats",
   "description": "Store flow information and show statistics about them.",
-  "version": "2022.3.0",
+  "version": "2023.1.0",
   "napp_dependencies": ["kytos/of_core"],
   "license": "",
   "tags": [],


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
